### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -192,7 +192,7 @@ License
 The pyexperiment package is licensed under an MIT licence (see the
 `LICENSE <https://github.com/duerrp/pyexperiment/blob/master/LICENSE>`__).
 
-.. |Development Status| image:: https://pypip.in/status/pyexperiment/badge.svg
+.. |Development Status| image:: https://img.shields.io/pypi/status/pyexperiment.svg
    :target: https://pypi.python.org/pypi/pyexperiment/
 .. |Version| image:: https://img.shields.io/pypi/v/pyexperiment.svg
    :target: https://pypi.python.org/pypi/pyexperiment/


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20pyexperiment))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `pyexperiment`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.