### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -355,7 +355,7 @@ epub_copyright = u'2015, Peter Duerr'
 # The format is a list of tuples containing the path and title.
 #epub_pre_files = []
 
-# HTML files shat should be inserted after the pages created by sphinx.
+# HTML files that should be inserted after the pages created by sphinx.
 # The format is a list of tuples containing the path and title.
 #epub_post_files = []
 

--- a/pyexperiment/replicate.py
+++ b/pyexperiment/replicate.py
@@ -1,6 +1,6 @@
 """Repliate allows running a target function multiple times.
 
-The number of replicates is defined by a confguration value and replicate can
+The number of replicates is defined by a configuration value and replicate can
 be run with or without multiprocessing.
 
 Written by Peter Duerr


### PR DESCRIPTION
There are small typos in:
- docs/conf.py
- pyexperiment/replicate.py

Fixes:
- Should read `configuration` rather than `confguration`.
- Should read `that` rather than `shat`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md